### PR TITLE
Fix Typo in FlyInEffect_7 in field_effect.c

### DIFF
--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -3549,7 +3549,7 @@ static void FlyInEffect_7(struct Task * task)
     {
         objectEvent = &gObjectEvents[gPlayerAvatar.objectEventId];
         state = PLAYER_AVATAR_STATE_NORMAL;
-        if (task->data[15] & PLAYER_AVATAR_STATE_SURFING)
+        if (task->data[15] & PLAYER_AVATAR_FLAG_SURFING)
         {
             state = PLAYER_AVATAR_STATE_SURFING;
             sub_80DC44C(objectEvent->fieldEffectSpriteId, 1);


### PR DESCRIPTION
You &ed the PlayerAvatar flags with PLAYER_AVATAR_STATE_SURFING instead of PLAYER_AVATAR_FLAG_SURFING in FlyInEffect_7 which led to a game freeze when landing from Fly. Fixed.